### PR TITLE
Avoid Skipping Stages (TLEG) & Fix Stage Count

### DIFF
--- a/Assets/SimonsStagesScript.cs
+++ b/Assets/SimonsStagesScript.cs
@@ -107,6 +107,7 @@ public class SimonsStagesScript : MonoBehaviour
     {
         if (!moduleLocked && !moduleSolved && gameOn && !readyToSolve && !secondAttempt && !flashingCurStage)
         {
+            solvedModules = Bomb.GetSolvedModuleNames().Where(x => !ignoredModules.Contains(x)).Count();
             if (moduleCount == 0 && !moduleSolved)
             {
                 moduleSolved = true;
@@ -114,12 +115,9 @@ public class SimonsStagesScript : MonoBehaviour
                 Debug.LogFormat("[Simon's Stages #{0}] There are no solveable modules on the bomb. Module disarmed.", moduleId);
                 StartCoroutine(SolveLights());
             }
-            else if (moduleCount != 1 && currentLevel < stagesToGenerate) // Replaced (solvedModules != moduleCount)
+            else if (moduleCount != 1 && solvedModules < stagesToGenerate + 1)  // Replaced (solvedModules != moduleCount)
             {
-                //tempSolvedModules = solvedModules;
-                solvedModules = Bomb.GetSolvedModuleNames().Where(x => !ignoredModules.Contains(x)).Count();
-                //if (tempSolvedModules != solvedModules)
-                if (currentLevel < solvedModules)// Replaced (solvedModules != moduleCount)
+                if (currentLevel < solvedModules && solvedModules < moduleCount)// Replaced (solvedModules != moduleCount)
                 {
                     GenerateSequence();
                 }


### PR DESCRIPTION
If two modules are now solved close to each other, the module will now display both stages in their entirety. Credit to TheLastExtremeGamer for doing that. I fixed up the number of stages / activation timing. 